### PR TITLE
Allow scoped paths to skip prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,18 @@ Use a prefix:
 ```js
 parse([
   'es2015',
-  'babel-preset-stage-2'
+  'babel-preset-stage-2',
+  '@scope/my-preset',
 ], { prefix: 'babel-preset-' })
 //=> return
 [
   require('$cwd/node_modules/babel-preset-es2015')(),
-  require('$cwd/node_modules/babel-preset-stage-2')()
+  require('$cwd/node_modules/babel-preset-stage-2')(),
+  require('$cwd/node_modules/@scope/my-preset')(),
 ]
 ```
+
+_Note: If the path is scoped (ie @scope/my-preset), prefix will be ignored_
 
 ### Pure object
 
@@ -147,8 +151,6 @@ Type: `string`<br>
 Default: `undefined`
 
 Prefix for package name.
-
-_If the path is scoped, prefix will be ignored_
 
 ##### isCalled
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Default: `undefined`
 
 Prefix for package name.
 
+_If the path is scoped, prefix will be ignored_
+
 ##### isCalled
 
 Type: `function`<br>

--- a/index.js
+++ b/index.js
@@ -17,11 +17,7 @@ function getFn(name, prefix, cwd) {
     return require(path.resolve(cwd, name))
   }
 
-  if (isScopedPath(name)) {
-    return require(path.join(cwd, 'node_modules', name))
-  }
-
-  if (prefix) {
+  if (prefix && !isScopedPath(name)) {
     const re = new RegExp(`^${prefix}`)
     name = re.test(name) ? name : `${prefix}${name}`
   }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function isLocalPath(input) {
 }
 
 function isScopedPath(input) {
-  return /^@/.test(input)
+  return /^@.*\//.test(input)
 }
 
 function getFn(name, prefix, cwd) {

--- a/index.js
+++ b/index.js
@@ -4,12 +4,16 @@ function isLocalPath(input) {
   return /^[./]|(^[a-zA-Z]:)/.test(input)
 }
 
+function isScopedPath(input) {
+  return /^@/.test(input)
+}
+
 function getFn(name, prefix, cwd) {
   if (typeof name === 'function') {
     return name
   }
 
-  if (isLocalPath(name)) {
+  if (isLocalPath(name) || isScopedPath(name)) {
     return require(path.resolve(cwd, name))
   }
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,12 @@ function getFn(name, prefix, cwd) {
     return name
   }
 
-  if (isLocalPath(name) || isScopedPath(name)) {
+  if (isLocalPath(name)) {
     return require(path.resolve(cwd, name))
+  }
+
+  if (isScopedPath(name)) {
+    return require(path.join(cwd, 'node_modules', name))
   }
 
   if (prefix) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test:cov": "jest --coverage && npm run lint",
     "test": "jest && npm run lint",
+    "test:watch": "jest --watch",
     "lint": "xo"
   },
   "author": "egoist <0x142857@gmail.com>",
@@ -24,7 +25,9 @@
   "devDependencies": {
     "jest-cli": "^19.0.0",
     "eslint-config-rem": "^3.0.0",
-    "xo": "^0.18.0"
+    "xo": "^0.18.0",
+    "@test/stub": "file:./test/fixture/stub-scoped",
+    "prefix-stub": "file:./test/fixture/stub-prefixed"
   },
   "xo": {
     "extends": "rem/prettier",

--- a/test/fixture/stub-prefixed/index.js
+++ b/test/fixture/stub-prefixed/index.js
@@ -1,0 +1,1 @@
+module.exports = () => 'prefixed'

--- a/test/fixture/stub-prefixed/package.json
+++ b/test/fixture/stub-prefixed/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "prefix-stub",
+  "main": "index.js",
+  "description": "fake prefixed module",
+  "license": "MIT"
+}

--- a/test/fixture/stub-scoped/index.js
+++ b/test/fixture/stub-scoped/index.js
@@ -1,0 +1,1 @@
+module.exports = () => 'scoped'

--- a/test/fixture/stub-scoped/package.json
+++ b/test/fixture/stub-scoped/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/stub",
+  "main": "index.js",
+  "description": "fake scoped module",
+  "license": "MIT"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,11 @@ describe('array', () => {
   })
 
   test('array of strings', () => {
-    const config = parse(['./test/fixture/foo', './test/fixture/bar', '@test/stub'])
+    const config = parse([
+      './test/fixture/foo',
+      './test/fixture/bar',
+      '@test/stub'
+    ])
     expect(config).toEqual(['foo', 'bar', 'scoped'])
   })
 
@@ -41,11 +45,7 @@ describe('object', () => {
 
 describe('prefixed', () => {
   test('ignores scoped packages', () => {
-    const config = parse([
-      'stub', '@test/stub'
-    ], {
-      prefix: 'prefix-',
-    })
+    const config = parse(['stub', '@test/stub'], { prefix: 'prefix-' })
     expect(config).toEqual(['prefixed', 'scoped'])
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,8 +16,8 @@ describe('array', () => {
   })
 
   test('array of strings', () => {
-    const config = parse(['./test/fixture/foo', './test/fixture/bar'])
-    expect(config).toEqual(['foo', 'bar'])
+    const config = parse(['./test/fixture/foo', './test/fixture/bar', '@test/stub'])
+    expect(config).toEqual(['foo', 'bar', 'scoped'])
   })
 
   test('array of strings with options', () => {
@@ -36,5 +36,16 @@ describe('object', () => {
       './test/fixture/bar.js': {}
     })
     expect(config).toEqual([1, 'bar'])
+  })
+})
+
+describe('prefixed', () => {
+  test('ignores scoped packages', () => {
+    const config = parse([
+      'stub', '@test/stub'
+    ], {
+      prefix: 'prefix-',
+    })
+    expect(config).toEqual(['prefixed', 'scoped'])
   })
 })

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
If you want to use scoped packages for a poi preset, poi tries to load it with a prefix attached.

I think if the path name is scoped it would never really make sense to use a prefix, because it would be counter-intuitive to remember that something like `@my-org/opinionated-build` would be converted to `@my-org/poi-preset-opinionated-build`

So I figured it made sense to treat it like a local path in this package.

What do you think? If there is a better place to handle this, let me know :)